### PR TITLE
Flatpak plugin updates:

### DIFF
--- a/maven-plugins/eclipse-flatpak-packager/src/main/java/org/eclipse/cbi/maven/plugins/flatpakager/CreateFlatpakMojo.java
+++ b/maven-plugins/eclipse-flatpak-packager/src/main/java/org/eclipse/cbi/maven/plugins/flatpakager/CreateFlatpakMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat, Inc. and others.
+ * Copyright (c) 2017, 2021 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -174,7 +174,7 @@ public class CreateFlatpakMojo extends AbstractMojo {
 
 	/**
 	 * The version of the Gnome runtime on which to build the Flatpak application.
-	 * Defaults to "3.32"
+	 * Defaults to "41"
 	 * 
 	 * @since 1.1.5
 	 */
@@ -183,7 +183,7 @@ public class CreateFlatpakMojo extends AbstractMojo {
 
 	/**
 	 * The minimum version of Flatpak needed at runtime, that this application will
-	 * support. Defaults to "1.0.2" (the version available on RHEL 7.6)
+	 * support. Defaults to "1.7.1"
 	 *
 	 * @since 1.1.5
 	 */
@@ -655,6 +655,7 @@ public class CreateFlatpakMojo extends AbstractMojo {
 			List<String> builderArgs = new ArrayList<>();
 			builderArgs.add("flatpak-builder");
 			builderArgs.add("--force-clean");
+			builderArgs.add("--disable-rofiles-fuse");
 			builderArgs.add("--disable-cache");
 			builderArgs.add("--disable-download");
 			builderArgs.add("--disable-updates");

--- a/maven-plugins/eclipse-flatpak-packager/src/main/java/org/eclipse/cbi/maven/plugins/flatpakager/model/Manifest.java
+++ b/maven-plugins/eclipse-flatpak-packager/src/main/java/org/eclipse/cbi/maven/plugins/flatpakager/model/Manifest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Red Hat, Inc. and others.
+ * Copyright (c) 2017, 2021 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 public abstract class Manifest {
 	public static final String DEFAULT_BRANCH = "master";
 	public static final String DEFAULT_RUNTIME = "org.gnome.Platform";
-	public static final String DEFAULT_RUNTIMEVERSION = "3.38";
+	public static final String DEFAULT_RUNTIMEVERSION = "41";
 	public static final String DEFAULT_SDK = "org.gnome.Sdk";
 	public static final String DEFAULT_COMMAND = "eclipse";
 	public static final String DEFAULT_FLATPAKVERSION = "1.7.1";

--- a/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/Flatpakager.java
+++ b/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/Flatpakager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat, Inc. and others.
+ * Copyright (c) 2018, 2021 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,6 +40,7 @@ public abstract class Flatpakager {
 		ImmutableList.Builder<String> builderArgs = ImmutableList.builder();
 		builderArgs.add("flatpak-builder");
 		builderArgs.add("--force-clean");
+		builderArgs.add("--disable-rofiles-fuse");
 		builderArgs.add("--disable-cache");
 		builderArgs.add("--disable-download");
 		builderArgs.add("--disable-updates");

--- a/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/FlatpakagerServlet.java
+++ b/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/FlatpakagerServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat, Inc. and others.
+ * Copyright (c) 2018, 2021 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -82,6 +82,8 @@ public abstract class FlatpakagerServlet extends HttpServlet {
 			packager().generateFlatpakRepo(facade.getBooleanParameter("sign"), packager().work().resolve(name));
 
 			Path tarball = tarballRepository();
+			long bytes = Files.size(tarball);
+			logger.info("Reply size: " + bytes + " bytes");
 			responseFacade.replyWithFile(REPLY_MEDIA_TYPE, tarball.getFileName().toString(), tarball);
 		} finally {
 			deleteTemporaryResource(packager().work());


### PR DESCRIPTION
* Bump default gnome runtime to 41
* Disable rofiles-fuse cache optimisation
* Fix some incorrect javadocs

Signed-off-by: Mat Booth <mat.booth@gmail.com>