### PR TITLE
Flatpak packaging webservice improvements

### DIFF
--- a/webservice/packaging/flatpak/etc/flatpak-packaging-service.properties
+++ b/webservice/packaging/flatpak/etc/flatpak-packaging-service.properties
@@ -37,12 +37,6 @@ server.service.pathspec=/flatpak-packaging-service
 
 ##
 # Mandatory
-# The absolute path to the Flatpak repository
-##
-flatpak.repository=/var/www/html/flatpak/repo
-
-##
-# Mandatory
 # The gpg key with which to sign the flatpak application
 ##
 flatpak.gpgkey=573CD528
@@ -54,10 +48,10 @@ flatpak.gpgkey=573CD528
 # flatpak.gpghome=/path/to/gpg/dir
 
 ##
-# Optional (default = 3min = 180sec)
-# In seconds.
+# Optional (default = 5min = 300sec)
+# The time to wait in seconds before sub-processes are killed.
 ##
-# flatpak.timeout=180 
+# flatpak.timeout=300
 
 ### Log4j configuration section
 

--- a/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/FlatpakagerProperties.java
+++ b/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/FlatpakagerProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat, Inc. and others.
+ * Copyright (c) 2018, 2022 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -21,14 +21,12 @@ import org.eclipse.cbi.webservice.util.PropertiesReader;
  */
 public class FlatpakagerProperties {
 
-	private static final String DEFAULT_TIMEOUT = Long.toString(TimeUnit.MINUTES.toSeconds(3));
+	private static final String DEFAULT_TIMEOUT = Long.toString(TimeUnit.MINUTES.toSeconds(5));
 	private static final String TIMEOUT = "flatpak.timeout";
 
 	private static final String DEFAULT_GPGHOME = Paths.get(System.getProperty("user.home"), ".gnupg").toString();
 	private static final String GPGHOME = "flatpak.gpghome";
 	private static final String GPGKEY = "flatpak.gpgkey";
-
-	private static final String REPO = "flatpak.repository";
 
 	private final PropertiesReader propertiesReader;
 
@@ -42,10 +40,6 @@ public class FlatpakagerProperties {
 
 	public String getGpgkey() {
 		return propertiesReader.getString(GPGKEY);
-	}
-
-	public Path getRepository() {
-		return propertiesReader.getPath(REPO);
 	}
 
 	public long getTimeout() {

--- a/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/FlatpakagerServer.java
+++ b/webservice/packaging/flatpak/src/main/java/org/eclipse/cbi/webservice/flatpakaging/FlatpakagerServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Red Hat, Inc. and others.
+ * Copyright (c) 2018, 2022 Red Hat, Inc. and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -54,8 +54,7 @@ public class FlatpakagerServer {
 			final ProcessExecutor executor = new ProcessExecutor.BasicImpl();
 			final FlatpakagerProperties conf = new FlatpakagerProperties(PropertiesReader.create(confPath));
 			final Flatpakager packager = Flatpakager.builder().processExecutor(executor).timeout(conf.getTimeout())
-					.gpgHome(conf.getGpghome()).gpgKey(conf.getGpgkey()).repository(conf.getRepository())
-					.work(tempFolder.resolve("work")).build();
+					.gpgHome(conf.getGpghome()).gpgKey(conf.getGpgkey()).work(tempFolder.resolve("work")).build();
 
 			final FlatpakagerServlet createServlet = FlatpakagerServlet.builder().tempFolder(tempFolder)
 					.packager(packager).build();


### PR DESCRIPTION
* Use build-bundle to send back a single file to the client, this way we
  no longer have to build a tarball and the transfer is smaller since we
  are not sending unnecessary deltas that can be generated by the client
* Confine all build state to the webservice's temp directory
* No need to specify repo location in webservice config
* Change flatpak packaging mojo to generate deltas locally after doing a
  remote build using the webservice

Change-Id: I2aa7e432480698adf4dcc94ca5fad93b487c414e
Signed-off-by: Mat Booth <mat.booth@gmail.com>