### PR TITLE
Fix site creation for maven plugins

### DIFF
--- a/maven-plugins/common/pom.xml
+++ b/maven-plugins/common/pom.xml
@@ -11,10 +11,10 @@
   <artifactId>cbi-maven-plugin-common</artifactId>
 
   <parent>
-    <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-build-parent</artifactId>
+    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+    <artifactId>maven-plugin-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
-    <relativePath>../../build-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <build>

--- a/maven-plugins/eclipse-cbi-plugin/pom.xml
+++ b/maven-plugins/eclipse-cbi-plugin/pom.xml
@@ -19,10 +19,10 @@
   <packaging>maven-plugin</packaging>
 
   <parent>
-    <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-build-parent</artifactId>
+    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+    <artifactId>maven-plugin-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
-    <relativePath>../../build-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/maven-plugins/eclipse-dmg-packager/pom.xml
+++ b/maven-plugins/eclipse-dmg-packager/pom.xml
@@ -19,10 +19,10 @@
   <packaging>maven-plugin</packaging>
 
   <parent>
-    <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-build-parent</artifactId>
+    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+    <artifactId>maven-plugin-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
-    <relativePath>../../build-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/maven-plugins/eclipse-flatpak-packager/pom.xml
+++ b/maven-plugins/eclipse-flatpak-packager/pom.xml
@@ -18,10 +18,10 @@
   <packaging>maven-plugin</packaging>
 
   <parent>
-    <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-build-parent</artifactId>
+    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+    <artifactId>maven-plugin-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
-    <relativePath>../../build-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/maven-plugins/eclipse-jarsigner-plugin/pom.xml
+++ b/maven-plugins/eclipse-jarsigner-plugin/pom.xml
@@ -18,10 +18,10 @@
   <packaging>maven-plugin</packaging>
 
   <parent>
-    <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-build-parent</artifactId>
+    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+    <artifactId>maven-plugin-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
-    <relativePath>../../build-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/maven-plugins/eclipse-macsigner-plugin/pom.xml
+++ b/maven-plugins/eclipse-macsigner-plugin/pom.xml
@@ -20,10 +20,10 @@
   <packaging>maven-plugin</packaging>
 
   <parent>
-    <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-build-parent</artifactId>
+    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+    <artifactId>maven-plugin-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
-    <relativePath>../../build-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/maven-plugins/eclipse-winsigner-plugin/pom.xml
+++ b/maven-plugins/eclipse-winsigner-plugin/pom.xml
@@ -20,10 +20,10 @@
   <packaging>maven-plugin</packaging>
 
   <parent>
-    <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-build-parent</artifactId>
+    <groupId>org.eclipse.cbi.maven.plugins</groupId>
+    <artifactId>maven-plugin-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
-    <relativePath>../../build-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <dependencies>

--- a/maven-plugins/pom.xml
+++ b/maven-plugins/pom.xml
@@ -16,8 +16,9 @@
 
   <parent>
     <groupId>org.eclipse.cbi</groupId>
-    <artifactId>cbi-parent</artifactId>
+    <artifactId>cbi-build-parent</artifactId>
     <version>1.4.3-SNAPSHOT</version>
+    <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
 
   <name>Eclipse CBI Maven Plugins</name>
@@ -35,7 +36,7 @@
     <module>eclipse-flatpak-packager</module>
   </modules>
 
-  <!-- <reporting>
+  <reporting>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -59,7 +60,11 @@
            </reportSet>
          </reportSets>
        </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-report-plugin</artifactId>
+      </plugin>
     </plugins>
-  </reporting> -->
+  </reporting>
 
 </project>

--- a/maven-plugins/src/site/site.xml
+++ b/maven-plugins/src/site/site.xml
@@ -12,7 +12,7 @@
 <project name="Eclipse CBI Plugins">
   <bannerLeft>
     <name>Eclipse</name>
-    <src>https://www.eclipse.org/artwork/images/v2/eclipse_foundation_logo.jpg</src>
+    <src>https://www.eclipse.org/org/artwork/images/eclipse_foundation_logo.jpg</src>
     <href>https://eclipse.org</href>
   </bannerLeft>
   <body>

--- a/pom.xml
+++ b/pom.xml
@@ -108,11 +108,16 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.1</version>
         </plugin>
-        <!-- <plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.1.1</version>
-        </plugin> -->
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-report-plugin</artifactId>
+          <version>3.9.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>


### PR DESCRIPTION
- change parent pom of Maven plugins to `maven-plugin-parent`
- change parent pom of  `maven-plugin-parent` to `cbi-build-parent`
- fix URL to Eclipse Foundation logo in site.xml
- the site can be generated by doing the following:
  1. Run `mvn clean install -DskipTests` in root dir
  2. Run `mvn clean verify site -DskipTests` in maven-plugins dir
  3. Run `mvn site:stage` in maven-plugins dir
  4. Site can be found at maven-plugins/target/staging/cbi-build-parent/maven-plugin-parent/index.html