### PR TITLE
Ensure webservices can be built with source level 11

### DIFF
--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
 
     <auto-value.version>1.10.4</auto-value.version>
   </properties>

--- a/maven-plugins/eclipse-cbi-plugin/pom.xml
+++ b/maven-plugins/eclipse-cbi-plugin/pom.xml
@@ -25,6 +25,10 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/maven-plugins/eclipse-jarsigner-plugin/pom.xml
+++ b/maven-plugins/eclipse-jarsigner-plugin/pom.xml
@@ -24,6 +24,10 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/OSSLCodesigner.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/OSSLCodesigner.java
@@ -19,6 +19,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
@@ -74,7 +75,7 @@ public abstract class OSSLCodesigner {
 				.add("-pass", pkcs12Password())
 				.add("-n", description())
 				.add("-i", uri().toString())
-				.addAll(timestampURIs().stream().map(x -> List.of("-t", x.toString())).flatMap(List::stream).toList())
+				.addAll(timestampURIs().stream().map(x -> List.of("-t", x.toString())).flatMap(List::stream).collect(Collectors.toList()))
 				.add("-in", in.toString())
 				.add("-out", out.toString())
 				.build();


### PR DESCRIPTION
The project had source level set to 17, which is not yet supportedd by the webservices as they run with jdk 11.

This fixes the setup to be able to build the project.
Some maven plugin already need java 17, which has been adjusted.

A follow up issue will be created to switch the whole code base to 17.