### PR TITLE
Enforce the use of Java 17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 
-.PHONY: clean jar-signing-service authenticode-signing macos
+.PHONY: all clean jar-signing-service authenticode-signing macos
 
-jar-signing:
+all: jar-signing authenticode-signing macos
+
+jar-signing: clean
 	./mvnw verify -am -pl webservice/signing/jar
 	./webservice/service-deployment.sh webservice/signing/jar/default.jsonnet
 	./webservice/service-deployment.sh webservice/signing/jar/jce.jsonnet
 
-authenticode-signing:
+authenticode-signing: clean
 	./mvnw verify -am -pl webservice/signing/windows
 	./webservice/service-deployment.sh webservice/signing/windows/service.jsonnet
 
-macos:
+macos: clean
 	jsonnet webservice/signing/macosx/services.jsonnet | jq -r '.["kube.yml"]'  | kubectl apply -f -
 	jsonnet webservice/packaging/dmg/services.jsonnet | jq -r '.["kube.yml"]'  | kubectl apply -f -
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CBI Maven plugins and digital signing services
 
+This project requires Java 17+.
+
 ## Deploy a new released version 
 
 * Build a release
@@ -23,4 +25,4 @@ VERSION="1.3.0"
 ## Deploy staging version (when version in pom is -SNAPSHOT)
 
 From a laptop with access to deployment cluster
-`make jar-signing authenticode-signing`
+`make clean jar-signing authenticode-signing`

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>${requireJavaVersion}</maven.compiler.release>
 
     <auto-value.version>1.10.4</auto-value.version>
   </properties>

--- a/maven-plugins/eclipse-cbi-plugin/pom.xml
+++ b/maven-plugins/eclipse-cbi-plugin/pom.xml
@@ -24,11 +24,7 @@
     <version>1.4.3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-
-  <properties>
-    <maven.compiler.release>17</maven.compiler.release>
-  </properties>
-
+  
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/maven-plugins/eclipse-jarsigner-plugin/pom.xml
+++ b/maven-plugins/eclipse-jarsigner-plugin/pom.xml
@@ -24,10 +24,6 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <properties>
-    <maven.compiler.release>17</maven.compiler.release>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <requireMavenVersion>3.6.3</requireMavenVersion>
+    <requireJavaVersion>17</requireJavaVersion>
   </properties>
 
   <build>
@@ -136,6 +137,9 @@
                 <requireMavenVersion>
                   <version>${requireMavenVersion}</version>
                 </requireMavenVersion>
+                <requireJavaVersion>
+                  <version>${requireJavaVersion}</version>
+                </requireJavaVersion>
                 <requireNoRepositories/>
                 <requirePluginVersions/>
                 <reactorModuleConvergence/>


### PR DESCRIPTION
This PR reverts the previous PR https://github.com/eclipse-cbi/org.eclipse.cbi/pull/365 which was a misunderstanding.
The project and all its modules run with Java 17 so we should use that as default as before but add additional enforce rules to require Java 17 when building the project to avoid mistakes.

Updating the readme as well and make sure that you do a make clean before deploying services.
