### PR TITLE
Add --skip-jenkins argument to create-dmg command

### DIFF
--- a/webservice/packaging/dmg/src/main/java/org/eclipse/cbi/webservice/dmgpackaging/DMGPackager.java
+++ b/webservice/packaging/dmg/src/main/java/org/eclipse/cbi/webservice/dmgpackaging/DMGPackager.java
@@ -57,6 +57,7 @@ public abstract class DMGPackager {
 	private ImmutableList<String> createCommand(Path appFolder, Path targetImageFile, Options options) {
 		ImmutableList.Builder<String> command = ImmutableList.builder();
 		command.add("./create-dmg/create-dmg");
+		command.add("--skip-jenkins");
 		
 		Splitter splitter = Splitter.on(' ').trimResults().omitEmptyStrings();
 		if (options.volumeName().isPresent())


### PR DESCRIPTION
This will avoid having to host a custom fork of create-dmg with the environment variable `SKIP_JENKINS` set to 1.

See https://github.com/create-dmg/create-dmg/blob/master/create-dmg#L33