### PR TITLE
Mark jar/mac/win-signer and dmgpackage plugins as being thread-safe

### DIFF
--- a/maven-plugins/eclipse-dmg-packager/src/main/java/org/eclipse/cbi/maven/plugins/dmgpackager/CreateDMGMojo.java
+++ b/maven-plugins/eclipse-dmg-packager/src/main/java/org/eclipse/cbi/maven/plugins/dmgpackager/CreateDMGMojo.java
@@ -42,7 +42,7 @@ import org.eclipse.cbi.maven.http.apache.ApacheHttpClient;
  * Create a DMG file from the file specified as argument. This plug-in requires
  * access to the Eclipse DMG packager web service.
  */
-@Mojo(name = "package-dmg", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "package-dmg", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class CreateDMGMojo extends AbstractMojo {
 
 	/**

--- a/maven-plugins/eclipse-jarsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/jarsigner/mojo/SignMojo.java
+++ b/maven-plugins/eclipse-jarsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/jarsigner/mojo/SignMojo.java
@@ -53,7 +53,7 @@ import org.eclipse.cbi.maven.plugins.jarsigner.RemoteJarSigner;
  * webservice. Only artifacts with {@code .jar} extension are signed, other
  * artifacts are not signed but a warning message is logged.
  */
-@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class SignMojo extends AbstractMojo {
 
 	/**

--- a/maven-plugins/eclipse-macsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/macsigner/SignMojo.java
+++ b/maven-plugins/eclipse-macsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/macsigner/SignMojo.java
@@ -46,7 +46,7 @@ import org.eclipse.cbi.maven.http.apache.ApacheHttpClient;
  * Signs OS X applications found in the project build directory using the
  * Eclipse OS X application signer webservice.
  */
-@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class SignMojo extends AbstractMojo {
 
 	/**

--- a/maven-plugins/eclipse-winsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/winsigner/SignMojo.java
+++ b/maven-plugins/eclipse-winsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/winsigner/SignMojo.java
@@ -46,7 +46,7 @@ import org.eclipse.cbi.maven.http.apache.ApacheHttpClient;
  * Signs executables found in the project build directory using the
  * Eclipse Windows executable signer webservice.
  */
-@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE)
+@Mojo(name = "sign", defaultPhase = LifecyclePhase.PACKAGE, threadSafe = true)
 public class SignMojo extends AbstractMojo {
 
 	/**


### PR DESCRIPTION
This fixes #496