### PR TITLE
feat: add support to specify a default sigfile parameter

### DIFF
--- a/webservice/signing/jar/default.jsonnet
+++ b/webservice/signing/jar/default.jsonnet
@@ -105,6 +105,13 @@ jarsigner.newDeployment("jar-signing", std.extVar("artifactId"), std.extVar("ver
 
       ##
       # Optional
+      # Force the sigfile to be named ECLIPSE_ for backwards compatibility
+      # unless the sigfile is specified in the incoming request
+      ##
+      jarsigner.sigfile.default=ECLIPSE_
+
+      ##
+      # Optional
       # The default keystore type is the one that is specified as the value
       # of the keystore.type property in the security properties file. The
       # security properties file is called java.security, and it resides in

--- a/webservice/signing/jar/src/main/java/org/eclipse/cbi/webservice/signing/jar/JarSigner.java
+++ b/webservice/signing/jar/src/main/java/org/eclipse/cbi/webservice/signing/jar/JarSigner.java
@@ -172,6 +172,8 @@ public abstract class JarSigner {
 
 		if (!Strings.isNullOrEmpty(sigFile)) {
 			command.add("-sigfile", sigFile);
+		} else if (!Strings.isNullOrEmpty(configuration().getSigFileDefault())) {
+			command.add("-sigfile", configuration().getSigFileDefault());
 		}
 
 		if (configuration().getKeystore() == null) {

--- a/webservice/signing/jar/src/main/java/org/eclipse/cbi/webservice/signing/jar/JarSignerConfiguration.java
+++ b/webservice/signing/jar/src/main/java/org/eclipse/cbi/webservice/signing/jar/JarSignerConfiguration.java
@@ -37,7 +37,14 @@ public interface JarSignerConfiguration {
 	 * @return the path to the keystore file.
 	 */
 	Path getKeystore();
-	
+
+	/**
+	 * Returns the default sigfile name if none is provided.
+	 *
+	 * @return the default sigfile name.
+	 */
+	String getSigFileDefault();
+
 	/**
 	 * Returns the type of keystore.
 	 * 

--- a/webservice/signing/jar/src/main/java/org/eclipse/cbi/webservice/signing/jar/JarSignerProperties.java
+++ b/webservice/signing/jar/src/main/java/org/eclipse/cbi/webservice/signing/jar/JarSignerProperties.java
@@ -41,6 +41,8 @@ public class JarSignerProperties implements JarSignerConfiguration {
 	private static final String JARSIGNER_BIN = "jarsigner.bin";
 	private static final String JARSIGNER_JAVA_ARGS = "jarsigner.javaargs";
 
+	private static final String JARSIGNER_SIGFILE_DEFAULT = "jarsigner.sigfile.default";
+
 	private static final String JARSIGNER_HTTP_PROXY_HOST = "jarsigner.http.proxy.host";
 	private static final String JARSIGNER_HTTPS_PROXY_HOST = "jarsigner.https.proxy.host";
 	
@@ -73,6 +75,11 @@ public class JarSignerProperties implements JarSignerConfiguration {
 	@Override
 	public String getJavaArgs() {
 		return propertiesReader.getString(JARSIGNER_JAVA_ARGS, "");
+	}
+
+	@Override
+	public String getSigFileDefault() {
+		return propertiesReader.getString(JARSIGNER_SIGFILE_DEFAULT, "");
 	}
 
 	/**

--- a/webservice/signing/jar/src/test/java/org/eclipse/cbi/webservice/signing/jar/TestServer.java
+++ b/webservice/signing/jar/src/test/java/org/eclipse/cbi/webservice/signing/jar/TestServer.java
@@ -183,6 +183,11 @@ public class TestServer {
 			return "";
 		}
 
+		@Override
+		public String getSigFileDefault() {
+			return null;
+		}
+
 		private Path checkJarSignerPath() {
 			final Path ret;
 			


### PR DESCRIPTION
This adds support for a default sigfile parameter for the jar signing service.

Various eclipse projects hardcode the name of the signature files added to their jars, so we want to force that to a fixed name "ECLIPSE_" for backwards compatibility reasons.

In the long term, all project should handle different signature files gracefully as the signature file is usually derived from the key name which might change any time.