### PR TITLE
feat: use jsign and Google KMS for authenticode signing

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -298,6 +298,11 @@
         <version>6.0</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>2.23.1</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-oauth2-http</artifactId>
         <version>1.23.0</version>

--- a/webservice/signing/jar/jce.jsonnet
+++ b/webservice/signing/jar/jce.jsonnet
@@ -4,10 +4,6 @@ jarsigner.newDeployment("jar-signing-jce", std.extVar("artifactId"), std.extVar(
   pathspec: "/jarsigner/jce/sign",
 
   keystore+: {
-    path: "/var/run/secrets/%s/" % $.name,
-    filename: "keystore.p12",
-    volumeName: "keystore",
-    secretName: "%s-keystore" % $.name,
     password: {
       pass: "IT/CBI/PKI/codesigning/eclipse.org.keystore.passwd",
       filename: "keystore.passwd",
@@ -24,38 +20,6 @@ jarsigner.newDeployment("jar-signing-jce", std.extVar("artifactId"), std.extVar(
           pass: "IT/CBI/PKI/codesigning/eclipse.org-4k.pkcs8.pem",
         },
       },
-    ],
-  },
-
-  kube+: {
-    resources: [
-      if resource.kind == "Deployment" then resource + {
-        spec+: {
-          template+: {
-            spec+: {
-              containers: [
-                if container.name == "service" then container + {
-                  volumeMounts+: [
-                    {
-                      mountPath: $.keystore.path,
-                      name: $.keystore.volumeName,
-                      readOnly: true
-                    },
-                  ],
-                } else container for container in super.containers
-              ],
-              volumes+: [
-                {
-                  name: $.keystore.volumeName,
-                  secret: {
-                    secretName: $.keystore.secretName,
-                  },
-                },
-              ],
-            },
-          },
-        },
-      } else resource for resource in super.resources
     ],
   },
 

--- a/webservice/signing/keystore.sh
+++ b/webservice/signing/keystore.sh
@@ -20,75 +20,72 @@ JSON_FILE="${1:-"/dev/stdin"}"
 SERVICE_JSON=$(<"${JSON_FILE}")
 TOOLS_IMAGE="eclipse-temurin:11-jdk"
 
-HAS_KEYSTORE="$(jq -r 'has("keystore")' <<<"${SERVICE_JSON}")"
-HAS_KMS="$(jq -r 'has("kms")' <<<"${SERVICE_JSON}")"
+KEYSTORE_TYPE="$(jq -r '.keystore.type // "P12"' <<<"${SERVICE_JSON}")"
 
-# If a java keystore has been configured
-if [ "${HAS_KEYSTORE}" = true ] ; then
-    TMPDIR="$(readlink -f "${TMPDIR:-/tmp}")"
-    KEYSTORE="$(mktemp)"
-    # remove the file immediately as keytool does not like empty files
-    rm -f "${KEYSTORE}"
-    KEYSTORE_PASSWD="$(mktemp)"
+TMPDIR="$(readlink -f "${TMPDIR:-/tmp}")"
+KEYSTORE="$(mktemp)"
+# remove the file immediately as keytool does not like empty files
+rm -f "${KEYSTORE}"
+KEYSTORE_PASSWD="$(mktemp)"
 
-    pass "$(jq -r '.keystore.password.pass' <<<"${SERVICE_JSON}")" > "${KEYSTORE_PASSWD}"
+pass "$(jq -r '.keystore.password.pass' <<<"${SERVICE_JSON}")" > "${KEYSTORE_PASSWD}"
 
-    for entry in $(jq -r '.keystore.entries | map(tostring) | join("\n")' <<<"${SERVICE_JSON}"); do
-      ENTRY_NAME="$(jq -r '.name' <<<"${entry}")"
+for entry in $(jq -r '.keystore.entries | map(tostring) | join("\n")' <<<"${SERVICE_JSON}"); do
+  ENTRY_NAME="$(jq -r '.name' <<<"${entry}")"
 
-      PRIVATE_KEY="$(mktemp)"
-      pass "$(jq -r '.privateKey.pass' <<<"${entry}")" > "${PRIVATE_KEY}"
+  CERTIFICATE_CHAIN="$(mktemp)"
+  # concatenate all certificates from entries.certificates inside certificateChain file
+  for CERTIFICATE in $(jq -r '.certificates | map(.pass) | join("\n")' <<<"${entry}"); do
+    pass "${CERTIFICATE}" >> "${CERTIFICATE_CHAIN}"
+  done;
 
-      CERTIFICATE_CHAIN="$(mktemp)"
-      # concatenate all certificates from entries.certificates inside certificateChain file
-      for CERTIFICATE in $(jq -r '.certificates | map(.pass) | join("\n")' <<<"${entry}"); do
-        pass "${CERTIFICATE}" >> "${CERTIFICATE_CHAIN}"
-      done;
+  if [ "${KEYSTORE_TYPE}" = "P12" ]; then
+    PRIVATE_KEY="$(mktemp)"
+    pass "$(jq -r '.privateKey.pass' <<<"${entry}")" > "${PRIVATE_KEY}"
 
-      # create a proper pfx/p12 file with certificate chain + privatekey
-      ENTRY_P12="$(mktemp)"
-      docker run --pull=always --rm -u $(id -u):$(id -g) -v "${TMPDIR}:${TMPDIR}" "${TOOLS_IMAGE}" /bin/bash -c \
-        "openssl pkcs12 -export -in \"${CERTIFICATE_CHAIN}\" -inkey \"${PRIVATE_KEY}\" -name \"${ENTRY_NAME}\" > \"${ENTRY_P12}\" -passout \"file:${KEYSTORE_PASSWD}\""
+    # create a proper pfx/p12 file with certificate chain + privatekey
+    ENTRY_P12="$(mktemp)"
+    docker run --pull=always --rm -u $(id -u):$(id -g) -v "${TMPDIR}:${TMPDIR}" "${TOOLS_IMAGE}" /bin/bash -c \
+      "openssl pkcs12 -export -in \"${CERTIFICATE_CHAIN}\" -inkey \"${PRIVATE_KEY}\" -name \"${ENTRY_NAME}\" > \"${ENTRY_P12}\" -passout \"file:${KEYSTORE_PASSWD}\""
 
-      # print certificate expiration date
-      echo -n "INFO: Certificate '${ENTRY_NAME}' expires on "
-      docker run --pull=always --rm -v "${TMPDIR}:${TMPDIR}" "${TOOLS_IMAGE}" /bin/bash -c \
-        "openssl pkcs12 -in \"${ENTRY_P12}\" -nodes -passin \"file:${KEYSTORE_PASSWD}\" | openssl x509 -noout -enddate | cut -d'=' -f2"
+    # print certificate expiration date
+    echo -n "INFO: Certificate '${ENTRY_NAME}' expires on "
+    docker run --pull=always --rm -q -v "${TMPDIR}:${TMPDIR}" "${TOOLS_IMAGE}" /bin/bash -c \
+      "openssl pkcs12 -in \"${ENTRY_P12}\" -nodes -passin \"file:${KEYSTORE_PASSWD}\" | openssl x509 -noout -enddate | cut -d'=' -f2"
 
-      # add the p12 cert to a java p12 keystore
-      docker run --pull=always --rm -u "${UID}" -v "${TMPDIR}:${TMPDIR}" "${TOOLS_IMAGE}" \
-        "keytool" -importkeystore -alias "${ENTRY_NAME}" \
-          -srckeystore "${ENTRY_P12}" \
-          -srcstoretype pkcs12 \
-          -srcstorepass:file "${KEYSTORE_PASSWD}" \
-          -destkeystore "${KEYSTORE}" \
-          -deststoretype pkcs12 \
-          -storepass:file "${KEYSTORE_PASSWD}"
+    # add the p12 cert to a java p12 keystore
+    docker run --pull=always --rm -u "${UID}" -v "${TMPDIR}:${TMPDIR}" "${TOOLS_IMAGE}" \
+      "keytool" -importkeystore -alias "${ENTRY_NAME}" \
+        -srckeystore "${ENTRY_P12}" \
+        -srcstoretype pkcs12 \
+        -srcstorepass:file "${KEYSTORE_PASSWD}" \
+        -destkeystore "${KEYSTORE}" \
+        -deststoretype pkcs12 \
+        -storepass:file "${KEYSTORE_PASSWD}"
 
-      rm -f "${PRIVATE_KEY}" "${CERTIFICATE_CHAIN}" "${ENTRY_P12}"
-    done
+    rm -f "${PRIVATE_KEY}" "${CERTIFICATE_CHAIN}" "${ENTRY_P12}"
 
-    # apply java p12 keystore to the cluster
-    kubectl create secret generic "$(jq -r '.keystore.secretName' <<<"${SERVICE_JSON}")" \
-      --namespace "$(jq -r '.kube.namespace' <<<"${SERVICE_JSON}")" \
-      --from-file="$(jq -r '.keystore.filename' <<<"${SERVICE_JSON}")"="${KEYSTORE}" \
-      --from-file="$(jq -r '.keystore.password.filename' <<<"${SERVICE_JSON}")"="${KEYSTORE_PASSWD}" \
-      --dry-run=client -o yaml | kubectl apply -f -
+  elif [ "${KEYSTORE_TYPE}" = "GOOGLECLOUD" ]; then
+    # print certificate expiration date
+    echo -n "INFO: Certificate '${ENTRY_NAME}' expires on "
+    docker run --pull=always --rm -q -v "${TMPDIR}:${TMPDIR}" "${TOOLS_IMAGE}" /bin/bash -c \
+      "openssl x509 -in \"${CERTIFICATE_CHAIN}\" -noout -enddate | cut -d'=' -f2"
 
-    rm -f "${KEYSTORE}" "${KEYSTORE_PASSWD}"
-fi
+    # copy certificate chain to keystore file
+    cp ${CERTIFICATE_CHAIN} ${KEYSTORE}
 
-# If a Google Cloud KMS provider has been configured
-if [ "${HAS_KMS}" = true ] ; then
-    CERTCHAIN="$(mktemp)"
-    CREDENTIALS="$(mktemp)"
+    rm -f "${CERTIFICATE_CHAIN}"
+  else
+    echo "ERROR: unexpected keystore type '${KEYSTORE_TYPE}'" 1>&2
+    exit 1
+  fi
+done
 
-    pass "$(jq -r '.kms.certchain.pass' <<<"${SERVICE_JSON}")" > "${CERTCHAIN}"
-    pass "$(jq -r '.kms.credentials.pass' <<<"${SERVICE_JSON}")" > "${CREDENTIALS}"
+# apply keystore to the cluster
+kubectl create secret generic "$(jq -r '.keystore.secretName' <<<"${SERVICE_JSON}")" \
+  --namespace "$(jq -r '.kube.namespace' <<<"${SERVICE_JSON}")" \
+  --from-file="$(jq -r '.keystore.filename' <<<"${SERVICE_JSON}")"="${KEYSTORE}" \
+  --from-file="$(jq -r '.keystore.password.filename' <<<"${SERVICE_JSON}")"="${KEYSTORE_PASSWD}" \
+  --dry-run=client -o yaml | kubectl apply -f -
 
-    kubectl create secret generic "$(jq -r '.kms.secretName' <<<"${SERVICE_JSON}")" \
-      --namespace "$(jq -r '.kube.namespace' <<<"${SERVICE_JSON}")" \
-      --from-file="$(jq -r '.kms.certchain.filename' <<<"${SERVICE_JSON}")"="${CERTCHAIN}" \
-      --from-file="$(jq -r '.kms.credentials.filename' <<<"${SERVICE_JSON}")"="${CREDENTIALS}" \
-      --dry-run=client -o yaml | kubectl apply -f -
-fi
+rm -f "${KEYSTORE}" "${KEYSTORE_PASSWD}"

--- a/webservice/signing/windows/pom.xml
+++ b/webservice/signing/windows/pom.xml
@@ -16,6 +16,10 @@
       <artifactId>jsign-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>

--- a/webservice/signing/windows/pom.xml
+++ b/webservice/signing/windows/pom.xml
@@ -10,6 +10,17 @@
     <version>1.5.1-SNAPSHOT</version>
   </parent>
 
+  <dependencies>
+    <dependency>
+      <groupId>net.jsign</groupId>
+      <artifactId>jsign-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-oauth2-http</artifactId>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/CodeSigner.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/CodeSigner.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse Foundation and others
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Thomas Neidhart - initial implementation
+ *******************************************************************************/
+package org.eclipse.cbi.webservice.signing.windows;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Interface for different tools to implement code signing.
+ */
+public interface CodeSigner {
+	Path sign(Path file) throws IOException;
+}

--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSigner.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSigner.java
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2022 Eclipse Foundation and others
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Mikaël Barbero - initial implementation
+ *******************************************************************************/
+package org.eclipse.cbi.webservice.signing.windows;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auto.value.AutoValue;
+import net.jsign.AuthenticodeSigner;
+import net.jsign.KeyStoreBuilder;
+import net.jsign.Signable;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.List;
+
+/**
+ * Using jsign to sign windows executables.
+ */
+@AutoValue
+public abstract class JSigner implements CodeSigner {
+
+	/**
+	 * The credential holder in case Google KMS is being used as signing backend.
+	 */
+	private GoogleCredentials kmsCredentials = null;
+
+	/**
+	 * Returns the configuration object for this JarSigner instance.
+	 *
+	 * @return the configuration for this JarSigner instance
+	 */
+	abstract JSignerProperties configuration();
+
+	abstract Path tempFolder();
+
+	/**
+	 * Creates and returns a new builder for this class.
+	 * 
+	 * @return a new builder for this class.
+	 */
+	public static Builder builder() {
+		return new AutoValue_JSigner.Builder();
+	}
+
+	@Override
+	public Path sign(Path file) {
+		try {
+			KeyStore keystore =
+					new KeyStoreBuilder()
+							.storetype(configuration().getStoreType())
+							.keystore(configuration().getKeystore())
+							.storepass(googleAccessToken())
+							.certfile(configuration().getCertificateChain().toFile())
+							.build();
+
+			AuthenticodeSigner signer =
+					new AuthenticodeSigner(keystore, configuration().getKeyAlias(), null)
+							.withProgramURL(configuration().getURI().toString())
+							.withProgramName(configuration().getDescription())
+							.withTimestamping(true)
+							.withTimestampingAuthority(configuration().getTimestampURIs().stream().map(URI::toString).toList().toArray(new String[0]))
+							.withTimestampingRetries(3);
+
+			try (Signable signable = Signable.of(file.toFile())) {
+				signer.sign(signable);
+			}
+
+			return file;
+		} catch (Exception ex) {
+			throw new RuntimeException("Failed signing of '" + file.getFileName() + "'", ex);
+		}
+	}
+
+	private void initKmsCredentialsIfNeeded() {
+		if (configuration().getGoogleCloudCredentials() != null) {
+			try {
+				kmsCredentials =
+					GoogleCredentials.fromStream(new FileInputStream(configuration().getGoogleCloudCredentials().toString()))
+								     .createScoped(List.of("https://www.googleapis.com/auth/cloudkms"));
+			} catch (IOException ex) {
+				// should not happen
+				throw new RuntimeException(ex);
+			}
+		}
+	}
+
+	private String googleAccessToken() {
+		if (kmsCredentials != null) {
+			try {
+				kmsCredentials.refreshIfExpired();
+				return kmsCredentials.getAccessToken().getTokenValue();
+			} catch (IOException ex) {
+				throw new RuntimeException(ex);
+			}
+		} else {
+			throw new RuntimeException("Tried to retrieve a Google Cloud Access Token while no credentials have been provided");
+		}
+	}
+
+	/**
+	 * A builder of JSigner.
+	 */
+	@AutoValue.Builder
+	public static abstract class Builder {
+
+		/**
+		 * Sets the configuration to use.
+		 *
+		 * @return this builder for daisy-chaining.
+		 */
+		abstract Builder configuration(JSignerProperties configuration);
+
+		abstract Builder tempFolder(Path tempFolder);
+
+		abstract JSigner autoBuild();
+
+		/**
+		 * Creates and returns a new JarSigner object with the state of this
+		 * builder.
+		 *
+		 * @return a new JarSigner object with the state of this builder.
+		 */
+		public JSigner build() {
+			JSigner jSigner = autoBuild();
+			jSigner.initKmsCredentialsIfNeeded();
+			return jSigner;
+		}
+	}
+
+}

--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSignerProperties.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSignerProperties.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse Foundation and others
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Thomas Neidhart - initial implementation
+ *******************************************************************************/
+package org.eclipse.cbi.webservice.signing.windows;
+
+import com.google.common.base.Strings;
+import org.eclipse.cbi.webservice.util.PropertiesReader;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Properties reader of {@link JSigner}.
+ */
+public class JSignerProperties {
+
+	private static final String JSIGN_URL = "windows.jsign.url";
+	private static final String JSIGN_DESCRIPTION = "windows.jsign.description";
+
+	private static final String JSIGN_STORETYPE = "windows.jsign.storetype";
+	private static final String JSIGN_KEYSTORE = "windows.jsign.keystore";
+	private static final String JSIGN_KEY_ALIAS = "windows.jsign.keyalias";
+	private static final String JSIGN_CERTCHAIN = "windows.jsign.certchain";
+	private static final String JSIGN_KMS_CREDENTIALS = "windows.jsign.kms.credentials";
+
+	private static final String JSIGN_TIMESTAMPURL = "windows.jsign.timestampurl";
+
+	private final PropertiesReader propertiesReader;
+
+	/**
+	 * Default constructor.
+	 *
+	 * @param propertiesReader
+	 *            the properties reader that will be used to read configuration
+	 *            value.
+	 */
+	public JSignerProperties(PropertiesReader propertiesReader) {
+		this.propertiesReader = propertiesReader;
+	}
+
+	public String getDescription() {
+		return propertiesReader.getString(JSIGN_DESCRIPTION);
+	}
+
+	public URI getURI() {
+		String value = propertiesReader.getString(JSIGN_URL);
+		try {
+			return new URI(value);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Property '" + JSIGN_URL + "' must be a valid URI (currently '" + value + "')", e);
+		}
+	}
+
+	public String getStoreType() {
+		return propertiesReader.getString(JSIGN_STORETYPE);
+	}
+
+	public String getKeystore() {
+		return propertiesReader.getString(JSIGN_KEYSTORE);
+	}
+
+	/**
+	 * Reads and returns the name of the alias of the key to be used in the
+	 * keystore.
+	 *
+	 * @return the name of the alias of the key to be used in the keystore.
+	 */
+	public String getKeyAlias() {
+		return propertiesReader.getString(JSIGN_KEY_ALIAS);
+	}
+
+	public Path getCertificateChain() {
+		String certchain = propertiesReader.getString(JSIGN_CERTCHAIN, "");
+		if (!Strings.isNullOrEmpty(certchain)) {
+			return propertiesReader.getRegularFile(JSIGN_CERTCHAIN);
+		} else {
+			throw new IllegalArgumentException("No certificate chain file configured");
+		}
+	}
+
+	public List<URI> getTimestampURIs() {
+		List<URI> result = new ArrayList<>();
+
+		int i = 1;
+		String value;
+
+		do {
+			String propertyKey = JSIGN_TIMESTAMPURL + "." + i++;
+			value = propertiesReader.getString(propertyKey, "undefined");
+			if (!value.equals("undefined")) {
+				try {
+					result.add(new URI(value));
+				} catch (URISyntaxException e) {
+					throw new IllegalArgumentException("Property '" + propertyKey + "' must be a valid URI (currently '" + value + "')", e);
+				}
+			}
+		} while (!value.equals("undefined"));
+
+		if (result.isEmpty()) {
+			throw new IllegalArgumentException("No timeserver uri configured, at least property '" + JSIGN_TIMESTAMPURL + ".1' is missing");
+		}
+
+		return result;
+	}
+
+	public Path getGoogleCloudCredentials() {
+		String credentials = propertiesReader.getString(JSIGN_KMS_CREDENTIALS, "");
+		if (!Strings.isNullOrEmpty(credentials)) {
+			return propertiesReader.getRegularFile(JSIGN_KMS_CREDENTIALS);
+		} else {
+			return null;
+		}
+	}
+}

--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/OSSLCodesigner.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/OSSLCodesigner.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @AutoValue
-public abstract class OSSLCodesigner {
+public abstract class OSSLCodesigner implements CodeSigner {
 
 	private static final String TEMP_FILE_PREFIX = OSSLCodesigner.class.getSimpleName() + "-";
 	private static final Logger logger = LoggerFactory.getLogger(OSSLCodesigner.class);

--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/SigningServlet.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/SigningServlet.java
@@ -13,6 +13,7 @@
 package org.eclipse.cbi.webservice.signing.windows;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.nio.file.Path;
 
 import com.google.auto.value.AutoValue;
@@ -31,6 +32,7 @@ import jakarta.servlet.http.HttpServletResponse;
 @AutoValue
 public abstract class SigningServlet extends HttpServlet {
 
+	@Serial
 	private static final long serialVersionUID = -7811488782781658819L;
 
 	private static final String FILE_PART_NAME = "file";
@@ -56,7 +58,7 @@ public abstract class SigningServlet extends HttpServlet {
 			String submittedFileName = requestFacade.getSubmittedFileName(FILE_PART_NAME).get();
 			if (submittedFileName.endsWith(".exe") || submittedFileName.endsWith(".dll") || submittedFileName.endsWith(".msi")) {
 				Path unsignedExe = requestFacade.getPartPath(FILE_PART_NAME, TEMP_FILE_PREFIX).get();
-				Path signedFile = osslCodesigner().sign(unsignedExe);
+				Path signedFile = codesigner().sign(unsignedExe);
 				responseFacade.replyWithFile(PORTABLE_EXECUTABLE_MEDIA_TYPE, submittedFileName, signedFile);
 			} else {
 				responseFacade.replyError(HttpServletResponse.SC_BAD_REQUEST, "Submitted '" + FILE_PART_NAME + "' '" + submittedFileName + "' must ends with '.exe' ");
@@ -70,14 +72,14 @@ public abstract class SigningServlet extends HttpServlet {
 		return new AutoValue_SigningServlet.Builder();
 	}
 	
-	abstract OSSLCodesigner osslCodesigner();
+	abstract CodeSigner codesigner();
 	abstract Path tempFolder();
 	
 	@AutoValue.Builder
 	public static abstract class Builder {
 		public abstract SigningServlet build();
 
-		public abstract Builder osslCodesigner(OSSLCodesigner codesigner);
+		public abstract Builder codesigner(CodeSigner codesigner);
 
 		public abstract Builder tempFolder(Path tempFolder);
 	}


### PR DESCRIPTION
This fixes #499  and #476 .

It applies similar changes as for the jar signing service for the windows signing service as well.
Instead of calling an external program, we can utilize the jsign core library to sign windows executables in pure java code.

The deployment descriptor needs to be updated and we should generate the final certificate chain from individual certificates as it was done previously. This applies to the jar signing service as well.

The change keeps the old mechanism to use osslsigncode in place and makes it possible to switch the actual implementation based on the provided configuration.

fyi: @ebourg