### PR TITLE
chore: support logging requests using log4j

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -177,6 +177,22 @@
         <artifactId>slf4j-reload4j</artifactId>
         <version>2.0.16</version>
       </dependency>
+      <dependency>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>1.2.25</version>
+      </dependency>
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>apache-log4j-extras</artifactId>
+        <version>1.2.17</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
 
       <!-- Maven plugins dependencies -->
       <dependency>

--- a/webservice/common/pom.xml
+++ b/webservice/common/pom.xml
@@ -33,6 +33,14 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>apache-log4j-extras</artifactId>
+    </dependency>
 
     <!-- Test dependencies -->
 

--- a/webservice/common/src/main/java/org/eclipse/cbi/webservice/server/EmbeddedServerProperties.java
+++ b/webservice/common/src/main/java/org/eclipse/cbi/webservice/server/EmbeddedServerProperties.java
@@ -17,6 +17,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Properties;
 
+import com.google.common.base.Strings;
 import org.eclipse.cbi.webservice.util.PropertiesReader;
 
 /**
@@ -61,21 +62,25 @@ public final class EmbeddedServerProperties implements EmbeddedServerConfigurati
 	 *
 	 * @return the path to the access log file
 	 * @throws IllegalStateException
-	 *             if the property is not specified or if the parent folder
-	 *             doesn't exist and can't be created.
+	 *             if the parent folder doesn't exist and can't be created.
 	 */
 	@Override
 	public Path getAccessLogFile() {
-		final Path logFilePath = propertiesReader.getPath(ACCESS_LOG_FILE);
-		final Path logFileParent = logFilePath.getParent();
-		if (!Files.exists(logFileParent)) {
-			try {
-				Files.createDirectories(logFileParent);
-			} catch (IOException e) {
-				throw new IllegalStateException("Folder '" + logFileParent + "' can not be created to contain the log files", e);
+		String accessLogFile = propertiesReader.getString(ACCESS_LOG_FILE, "");
+		if (!Strings.isNullOrEmpty(accessLogFile)) {
+			final Path logFilePath = propertiesReader.getPath(ACCESS_LOG_FILE);
+			final Path logFileParent = logFilePath.getParent();
+			if (!Files.exists(logFileParent)) {
+				try {
+					Files.createDirectories(logFileParent);
+				} catch (IOException e) {
+					throw new IllegalStateException("Folder '" + logFileParent + "' can not be created to contain the log files", e);
+				}
 			}
+			return logFilePath;
+		} else {
+			return null;
 		}
-		return logFilePath;
 	}
 
 	/**

--- a/webservice/common/src/main/java/org/eclipse/cbi/webservice/servlet/RequestFacade.java
+++ b/webservice/common/src/main/java/org/eclipse/cbi/webservice/servlet/RequestFacade.java
@@ -296,12 +296,12 @@ public abstract class RequestFacade implements Closeable {
 	}
 
 	@Override
-	public void close() throws IOException {
+	public void close() {
 		partToDelete.forEach(p -> {
 			try {
 				p.delete();
 			} catch (Exception e) {
-				logger.error("Error occured while deleting a temporary resource", e);
+				logger.error("Error occurred while deleting a temporary resource", e);
 			}
 		});
 	}
@@ -320,7 +320,7 @@ public abstract class RequestFacade implements Closeable {
 
 	/**
 	 * Generates a valid random path in {@link #tempFolder() the temporary
-	 * folder}. It is valid in the sense that it does not exists when returned.
+	 * folder}. It is valid in the sense that it does not exist when returned.
 	 */
 	private Path generatePath(String prefix, String suffix) {
 		Path ret = null;

--- a/webservice/common/src/main/java/org/eclipse/cbi/webservice/util/PropertiesReader.java
+++ b/webservice/common/src/main/java/org/eclipse/cbi/webservice/util/PropertiesReader.java
@@ -177,7 +177,7 @@ public class PropertiesReader {
 			path = path.toAbsolutePath();
 		}
 		if (!Files.isRegularFile(path)) {
-			throw new IllegalStateException("Property '" + propertyName + "' does not reference an existing regular file '" + path.toString() + "'");
+			throw new IllegalStateException("Property '" + propertyName + "' does not reference an existing regular file '" + path + "'");
 		}
 		return path;
 	}

--- a/webservice/common/src/test/java/org/eclipse/cbi/webservice/server/EmbeddedServerPropertiesTest.java
+++ b/webservice/common/src/test/java/org/eclipse/cbi/webservice/server/EmbeddedServerPropertiesTest.java
@@ -12,9 +12,6 @@
  *******************************************************************************/
 package org.eclipse.cbi.webservice.server;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -27,14 +24,16 @@ import org.junit.Test;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 
+import static org.junit.Assert.*;
+
 @SuppressWarnings("javadoc")
 public class EmbeddedServerPropertiesTest {
 
-	@Test(expected=IllegalStateException.class)
+	@Test
 	public void testEmptyPropertiesGetAccessLog() throws IOException {
 		try (FileSystem fs = Jimfs.newFileSystem(Configuration.unix())) {
 			EmbeddedServerConfiguration propertiesReader = new EmbeddedServerProperties(new PropertiesReader(new Properties(), fs));
-			propertiesReader.getAccessLogFile();
+			assertNull(propertiesReader.getAccessLogFile());
 		}
 	}
 

--- a/webservice/signing/jar/default.jsonnet
+++ b/webservice/signing/jar/default.jsonnet
@@ -32,9 +32,10 @@ jarsigner.newDeployment("jar-signing", std.extVar("artifactId"), std.extVar("ver
       server.port=%(port)s
 
       ##
-      # Mandatory
+      # Optional
+      # Capture access log using log4j
       ##
-      server.access.log=%(logFolder)s/access-yyyy_mm_dd.log
+      # server.access.log=%(logFolder)s/access-yyyy_mm_dd.log
 
       ##
       # Mandatory
@@ -122,6 +123,10 @@ jarsigner.newDeployment("jar-signing", std.extVar("artifactId"), std.extVar("ver
       # Root logger option
       log4j.rootLogger=INFO, console, file
 
+      # Capture jetty requests
+      log4j.logger.org.eclipse.jetty.server.RequestLog=INFO, console, access-log
+      log4j.additivity.org.eclipse.jetty.server.RequestLog=false
+
       log4j.appender.console=org.apache.log4j.ConsoleAppender
       log4j.appender.console.layout=org.apache.log4j.PatternLayout
       log4j.appender.console.layout.ConversionPattern=%%d{yyyy-MM-dd HH:mm:ss} %%-5p %%c{1}:%%L - %%m%%n
@@ -133,6 +138,14 @@ jarsigner.newDeployment("jar-signing", std.extVar("artifactId"), std.extVar("ver
       log4j.appender.file.MaxBackupIndex=10
       log4j.appender.file.layout=org.apache.log4j.PatternLayout
       log4j.appender.file.layout.ConversionPattern=%%d{yyyy-MM-dd HH:mm:ss} %%-5p %%c{1}:%%L - %%m%%n
+
+      # Redirect requests to a separate access log file, support time based file rolling.
+      log4j.appender.access-log=org.apache.log4j.rolling.RollingFileAppender
+      log4j.appender.access-log.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
+      log4j.appender.access-log.RollingPolicy.ActiveFileName = %(logFolder)s/access.log
+      log4j.appender.access-log.RollingPolicy.FileNamePattern = %(logFolder)s/access-%d{yyyy-MM-dd}.log
+      log4j.appender.access-log.layout=org.apache.log4j.PatternLayout
+      log4j.appender.access-log.layout.ConversionPattern=%m%n
     ||| % $ {
       jarFile: "/usr/local/%s/%s-%s.jar" % [ $.name, $.artifactId, $.version ],
       credentialsFile: "%s/%s" % [ $.keystore.path, $.keystore.password.filename ],

--- a/webservice/signing/jar/jce.jsonnet
+++ b/webservice/signing/jar/jce.jsonnet
@@ -31,9 +31,10 @@ jarsigner.newDeployment("jar-signing-jce", std.extVar("artifactId"), std.extVar(
       server.port=%(port)s
 
       ##
-      # Mandatory
+      # Optional
+      # Capture access log using log4j
       ##
-      server.access.log=%(logFolder)s/access-yyyy_mm_dd.log
+      # server.access.log=%(logFolder)s/access-yyyy_mm_dd.log
 
       ##
       # Mandatory
@@ -111,6 +112,10 @@ jarsigner.newDeployment("jar-signing-jce", std.extVar("artifactId"), std.extVar(
       # Root logger option
       log4j.rootLogger=INFO, console, file
 
+      # Capture jetty requests
+      log4j.logger.org.eclipse.jetty.server.RequestLog=INFO, console, access-log
+      log4j.additivity.org.eclipse.jetty.server.RequestLog=false
+
       log4j.appender.console=org.apache.log4j.ConsoleAppender
       log4j.appender.console.layout=org.apache.log4j.PatternLayout
       log4j.appender.console.layout.ConversionPattern=%%d{yyyy-MM-dd HH:mm:ss} %%-5p %%c{1}:%%L - %%m%%n
@@ -122,6 +127,14 @@ jarsigner.newDeployment("jar-signing-jce", std.extVar("artifactId"), std.extVar(
       log4j.appender.file.MaxBackupIndex=10
       log4j.appender.file.layout=org.apache.log4j.PatternLayout
       log4j.appender.file.layout.ConversionPattern=%%d{yyyy-MM-dd HH:mm:ss} %%-5p %%c{1}:%%L - %%m%%n
+
+      # Redirect requests to a separate access log file, support time based file rolling.
+      log4j.appender.access-log=org.apache.log4j.rolling.RollingFileAppender
+      log4j.appender.access-log.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
+      log4j.appender.access-log.RollingPolicy.ActiveFileName = %(logFolder)s/access.log
+      log4j.appender.access-log.RollingPolicy.FileNamePattern = %(logFolder)s/access-%d{yyyy-MM-dd}.log
+      log4j.appender.access-log.layout=org.apache.log4j.PatternLayout
+      log4j.appender.access-log.layout.ConversionPattern=%m%n
     ||| % $ {
       keystoreFile: "%s/%s" % [ $.keystore.path, $.keystore.filename ],
       keystorePasswdFile: "%s/%s" % [ $.keystore.path, $.keystore.password.filename ],

--- a/webservice/signing/windows/service.jsonnet
+++ b/webservice/signing/windows/service.jsonnet
@@ -74,9 +74,10 @@ deployment.newDeployment("authenticode-signing", std.extVar("artifactId"), std.e
       server.port=%(port)s
 
       ##
-      # Mandatory
+      # Optional
+      # Capture access log using log4j
       ##
-      server.access.log=%(logFolder)s/access-yyyy_mm_dd.log
+      # server.access.log=%(logFolder)s/access-yyyy_mm_dd.log
 
       ##
       # Mandatory
@@ -153,6 +154,10 @@ deployment.newDeployment("authenticode-signing", std.extVar("artifactId"), std.e
       # Root logger option
       log4j.rootLogger=INFO, console, file
 
+      # Capture jetty requests
+      log4j.logger.org.eclipse.jetty.server.RequestLog=INFO, console, access-log
+      log4j.additivity.org.eclipse.jetty.server.RequestLog=false
+
       log4j.appender.console=org.apache.log4j.ConsoleAppender
       log4j.appender.console.layout=org.apache.log4j.PatternLayout
       log4j.appender.console.layout.ConversionPattern=%%d{yyyy-MM-dd HH:mm:ss} %%-5p %%c{1}:%%L - %%m%%n
@@ -164,6 +169,14 @@ deployment.newDeployment("authenticode-signing", std.extVar("artifactId"), std.e
       log4j.appender.file.MaxBackupIndex=10
       log4j.appender.file.layout=org.apache.log4j.PatternLayout
       log4j.appender.file.layout.ConversionPattern=%%d{yyyy-MM-dd HH:mm:ss} %%-5p %%c{1}:%%L - %%m%%n
+
+      # Redirect requests to a separate access log file, support time based file rolling.
+      log4j.appender.access-log=org.apache.log4j.rolling.RollingFileAppender
+      log4j.appender.access-log.RollingPolicy = org.apache.log4j.rolling.TimeBasedRollingPolicy
+      log4j.appender.access-log.RollingPolicy.ActiveFileName = %(logFolder)s/access.log
+      log4j.appender.access-log.RollingPolicy.FileNamePattern = %(logFolder)s/access-%d{yyyy-MM-dd}.log
+      log4j.appender.access-log.layout=org.apache.log4j.PatternLayout
+      log4j.appender.access-log.layout.ConversionPattern=%m%n
     ||| % $ {
       credentialsFile: "%s/%s" % [ $.keystore.path, $.keystore.password.filename ],
       certChainFile: "%s/%s" % [ $.keystore.path, $.keystore.filename ],


### PR DESCRIPTION
This PR changes the signing services such that request logs are not logged anymore via jetty but rather using log4j configuration.

That allows us to also route the access log to stdout to make it easier to get logs from pods e.g. using kubectl.