### PR TITLE
Support jsign without google cloud platform

### DIFF
--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSigner.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSigner.java
@@ -114,7 +114,7 @@ public abstract class JSigner implements CodeSigner {
 				throw new RuntimeException(ex);
 			}
 		} else {
-			return "NONE";
+			throw new RuntimeException("Tried to retrieve a Google Cloud Access Token while no credentials have been provided");
 		}
 	}
 

--- a/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSignerProperties.java
+++ b/webservice/signing/windows/src/main/java/org/eclipse/cbi/webservice/signing/windows/JSignerProperties.java
@@ -30,6 +30,7 @@ public class JSignerProperties {
 	private static final String JSIGN_DESCRIPTION = "windows.jsign.description";
 
 	private static final String JSIGN_STORETYPE = "windows.jsign.storetype";
+	private static final String JSIGN_STOREPASS = "windows.jsign.storepass";
 	private static final String JSIGN_KEYSTORE = "windows.jsign.keystore";
 	private static final String JSIGN_KEY_ALIAS = "windows.jsign.keyalias";
 	private static final String JSIGN_CERTCHAIN = "windows.jsign.certchain";
@@ -65,6 +66,10 @@ public class JSignerProperties {
 
 	public String getStoreType() {
 		return propertiesReader.getString(JSIGN_STORETYPE);
+	}
+
+	public String getStorePass() {
+		return propertiesReader.getString(JSIGN_STOREPASS);
 	}
 
 	public String getKeystore() {


### PR DESCRIPTION
If no `kmsCredentials` credentials are provided jsign can also use a PKCS#11 keystore and a storepass.