### PR TITLE
Ensure parent directory exists when writing destination in scanner-mojos

### DIFF
--- a/maven-plugins/eclipse-cbi-plugin/src/main/java/org/eclipse/cbi/mojo/AbstractPluginScannerMojo.java
+++ b/maven-plugins/eclipse-cbi-plugin/src/main/java/org/eclipse/cbi/mojo/AbstractPluginScannerMojo.java
@@ -58,7 +58,9 @@ abstract class AbstractPluginScannerMojo extends AbstractMojo {
         processPlugins(properties, manifests);
       }
 
-      try (OutputStream os = new BufferedOutputStream(new FileOutputStream(getDestination()))) {
+      File destination = getDestination();
+      destination.getParentFile().mkdirs();
+      try (OutputStream os = new BufferedOutputStream(new FileOutputStream(destination))) {
         properties.store(os, null);
       }
     } catch (Exception e) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-cbi/org.eclipse.cbi/issues/748