### PR TITLE
Introduce skip parameter for winsigner and macsigner Maven plugins

### DIFF
--- a/maven-plugins/eclipse-macsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/macsigner/SignMojo.java
+++ b/maven-plugins/eclipse-macsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/macsigner/SignMojo.java
@@ -231,9 +231,21 @@ public class SignMojo extends AbstractMojo {
 	 */
 	@Parameter(property = "cbi.macsigner.timeoutMillis", defaultValue = "0")
 	private int timeoutMillis;
+	
+	/**
+	 * Skips the execution of this plugin.
+	 * 
+	 * @since 1.5.4
+	 */
+	@Parameter(property = "cbi.macsigner.skip", defaultValue = "false")
+	private boolean skip;
 
 	@Override
 	public void execute() throws MojoExecutionException {
+		if (skip) {
+			getLog().info("Skip Mac signing");
+			return;
+		}
 		HttpClient httpClient = RetryHttpClient.retryRequestOn(ApacheHttpClient.create(new MavenLogger(getLog())))
 				.maxRetries(retryLimit()).waitBeforeRetry(retryTimer(), TimeUnit.SECONDS).log(new MavenLogger(getLog()))
 				.build();

--- a/maven-plugins/eclipse-winsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/winsigner/SignMojo.java
+++ b/maven-plugins/eclipse-winsigner-plugin/src/main/java/org/eclipse/cbi/maven/plugins/winsigner/SignMojo.java
@@ -244,8 +244,20 @@ public class SignMojo extends AbstractMojo {
 	@Parameter(property = "cbi.winsigner.timeoutMillis", defaultValue = "0")
 	private int timeoutMillis;
 
+	/**
+	 * Skips the execution of this plugin.
+	 * 
+	 * @since 1.5.4
+	 */
+	@Parameter(property = "cbi.winsigner.skip", defaultValue = "false")
+	private boolean skip;
+
 	@Override
 	public void execute() throws MojoExecutionException {
+		if (skip) {
+			getLog().info("Skip Windows signing");
+			return;
+		}
 		HttpClient httpClient = RetryHttpClient.retryRequestOn(ApacheHttpClient.create(new MavenLogger(getLog())))
 			.maxRetries(retryLimit())
 			.waitBeforeRetry(retryTimer(), TimeUnit.SECONDS)


### PR DESCRIPTION
This simplifies the unification of configuration and execution of these plugins in a parent pom file (and e.g. skip it for all except for selected child projects).