### PR TITLE
Run deploy with Java 21

### DIFF
--- a/.github/workflows/deploy-maven-site.yml
+++ b/.github/workflows/deploy-maven-site.yml
@@ -21,10 +21,10 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
       - name: Build and deploy site to local dir


### PR DESCRIPTION
Needed because https://github.com/eclipse-cbi/org.eclipse.cbi/pull/781 introduced Maven plugin that requires Java 21