### PR TITLE
Group codeql-action dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  groups:
+    codeql-action:
+      patterns:
+      - "github/codeql-action*"


### PR DESCRIPTION
The github/codeql-action init, autobuild, and analyze sub-actions must be updated together; separate PRs fail due to version mismatch.