### PR TITLE
Migrate from Jetty 11 to Jetty 12 (EE9)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty-version>11.0.26</jetty-version>
+    <jetty-version>12.0.37</jetty-version>
     <auto-value.version>1.11.1</auto-value.version> <!-- also defined in parent pom for annotation processor -->
     <apache-httpclient-version>4.5.14</apache-httpclient-version>
     <maven-api-version>3.9.16</maven-api-version>
@@ -169,8 +169,8 @@
         <version>${jetty-version}</version>
       </dependency>
       <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-servlet</artifactId>
+        <groupId>org.eclipse.jetty.ee9</groupId>
+        <artifactId>jetty-ee9-servlet</artifactId>
         <version>${jetty-version}</version>
       </dependency>
       <dependency>

--- a/maven-plugins/common/pom.xml
+++ b/maven-plugins/common/pom.xml
@@ -77,5 +77,10 @@
       <artifactId>jetty-server</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/maven-plugins/common/src/test/java/org/eclipse/cbi/maven/common/http/apache/ApacheHttpClientTest.java
+++ b/maven-plugins/common/src/test/java/org/eclipse/cbi/maven/common/http/apache/ApacheHttpClientTest.java
@@ -3,6 +3,7 @@ package org.eclipse.cbi.maven.common.http.apache;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -20,16 +21,16 @@ import org.eclipse.cbi.maven.http.HttpRequest;
 import org.eclipse.cbi.maven.http.HttpRequest.Builder;
 import org.eclipse.cbi.maven.http.HttpResult;
 import org.eclipse.cbi.maven.http.apache.ApacheHttpClient;
+import org.eclipse.jetty.ee9.nested.AbstractHandler;
+import org.eclipse.jetty.ee9.nested.ContextHandler;
+import org.eclipse.jetty.ee9.nested.Handler;
+import org.eclipse.jetty.ee9.nested.Request;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkConnector;
-import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
@@ -127,7 +128,8 @@ public class ApacheHttpClientTest {
 
 	private static Server createProcessingServer(Handler handler) throws Exception {
 		Server server = new Server(0);
-        server.setHandler(handler);
+        ContextHandler context = new ContextHandler("/", handler);
+        server.setHandler(context.get());
         server.start();
         return server;
 	}
@@ -140,7 +142,7 @@ public class ApacheHttpClientTest {
 		return new AbstractHandler() {
 			@Override
 			public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-				baseRequest.setAttribute(Request.__MULTIPART_CONFIG_ELEMENT, new MultipartConfigElement(""));
+            baseRequest.setAttribute(Request.MULTIPART_CONFIG_ELEMENT, new MultipartConfigElement(""));
 				assertEquals("/processing-service", target);
 				assertTrue(request.getContentType().startsWith(ContentType.MULTIPART_FORM_DATA.getMimeType()));
 				assertTrue(HttpMethod.POST.is(request.getMethod()));

--- a/webservice/common/pom.xml
+++ b/webservice/common/pom.xml
@@ -26,8 +26,8 @@
       <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
+      <groupId>org.eclipse.jetty.ee9</groupId>
+      <artifactId>jetty-ee9-servlet</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/webservice/common/src/main/java/org/eclipse/cbi/webservice/server/EmbeddedErrorHandler.java
+++ b/webservice/common/src/main/java/org/eclipse/cbi/webservice/server/EmbeddedErrorHandler.java
@@ -26,10 +26,10 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MimeTypes;
-import org.eclipse.jetty.server.Dispatcher;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
-import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.ee9.nested.Dispatcher;
+import org.eclipse.jetty.ee9.nested.Request;
+import org.eclipse.jetty.ee9.nested.Response;
+import org.eclipse.jetty.ee9.nested.ErrorHandler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/webservice/common/src/main/java/org/eclipse/cbi/webservice/server/EmbeddedServer.java
+++ b/webservice/common/src/main/java/org/eclipse/cbi/webservice/server/EmbeddedServer.java
@@ -28,10 +28,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.apache.log4j.PropertyConfigurator;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.eclipse.jetty.server.handler.RequestLogHandler;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
@@ -262,8 +260,6 @@ public abstract class EmbeddedServer {
 		contextHandler.addServlet(createHeartbeatServlet(), "/heartbeat");
 		contextHandler.addServlet(createVersionServlet(), "/version");
 
-		RequestLogHandler requestLogHandler = new RequestLogHandler();
-
 		final RequestLog.Writer logWriter;
 		if (accessLogFile() != null) {
 			RequestLogWriter myLogWriter = new RequestLogWriter(accessLogFile().toString());
@@ -279,14 +275,12 @@ public abstract class EmbeddedServer {
 		// do not log requests for the heartbeat servlet
 		requestLog.setIgnorePaths(new String[] {"/heartbeat"});
 
-		requestLogHandler.setRequestLog(requestLog);
+		server.setRequestLog(requestLog);
 
-		HandlerCollection handlers = new HandlerCollection();
-		handlers.setHandlers(new Handler[] {
-				contextHandler,
-				new DefaultHandler(),
-				requestLogHandler
-		});
+		Handler.Sequence handlers = new Handler.Sequence(
+				contextHandler.get(),
+				new DefaultHandler()
+		);
 		server.setHandler(handlers);
 
 		server.start();


### PR DESCRIPTION
Jetty 11.0.26 has no fix for CVE-2026-6790 (GHSA-7p3p-8qv8-m2vh, HTTP Authority/Host mismatch); the fix ships only in Jetty 12. Move to Jetty 12.0.37 using the EE9 environment, which keeps the existing jakarta.servlet (Servlet 5.0) namespace the code already uses.

- bom/pom.xml: bump jetty-version to 12.0.37, swap jetty-servlet for org.eclipse.jetty.ee9:jetty-ee9-servlet.
- webservice/common, maven-plugins/common: matching dependency swaps.
- EmbeddedServer: use org.eclipse.jetty.ee9.servlet.*; RequestLogHandler is removed in Jetty 12, so set the request log on the server and compose the root handler tree with core Handler.Sequence via ServletContextHandler.get().
- EmbeddedErrorHandler: switch to org.eclipse.jetty.ee9.nested.* (API preserved).
- ApacheHttpClientTest: switch to org.eclipse.jetty.ee9.nested.* and bridge the handler to the core Server through an ee9 ContextHandler.